### PR TITLE
Updates dependency versions to current or last compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/artisonian/erudite",
   "dependencies": {
-    "babel-core": "^5.0.0",
-    "marked": "^0.3.3",
-    "minimist": "^1.1.0",
-    "object-assign": "^2.0.0"
+    "babel-core": "^5.8.0",
+    "marked": "^0.3.6",
+    "minimist": "^1.2.0",
+    "object-assign": "^4.1.0"
   },
   "devDependencies": {
     "docco": "^0.7.0",


### PR DESCRIPTION
marked at v0.3.3 is considered insecure. babel-core would be 6.21.x at current version, but that appears to be incompatible with the code as is, Updated instead to 5.8.x, which seems to have been the last pre-6.x release of babel-core.

You can check out dependency status here: https://david-dm.org/artisonian/erudite