### PR TITLE
Upgrade to Babel 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+    - '0.10'
+    - '0.12'
+    - '4'
+    - '6'
+sudo: false
+script: npm test

--- a/bin/erudite
+++ b/bin/erudite
@@ -12,8 +12,12 @@ var usage = [
   '',
   '  -h, --help     show this help text',
   '  -o, --outfile  write to the given file path',
+  '      --preset   Babel preset to use (can be repeated)',
   '  -e, --stage    ECMAScript proposal stage (0-4)',
   '      --stdout   write to stdout (ignores --outfile)'
+  '',
+  'When specifying presets for Babel, these will need to be installed so they',
+  'can be loaded.'
 ].join('\n') + '\n\n';
 
 var filename = argv._[0];
@@ -30,12 +34,13 @@ if (!fs.existsSync(filename)) {
   process.exit(1);
 }
 
-var presets = []; // presets must be installed in the calling environment
-                  // (whether local or global), so do not enforce any
+var presets = argv.preset || []; // presets must be installed in the calling
+                                 // environment, so do not enforce any
+if ('string' === typeof presets) presets = [presets];
 var opts = { presets: presets };
 // note that -e or --stage may be specified as 0, hence need to test for undef
 var stage_preset = argv.e === undefined ? argv.stage : argv.e;
-if (stage_preset !== undefined) opts.presets.push('stage-' + argv.stage);
+if (stage_preset !== undefined) opts.presets.push('stage-' + stage_preset);
 var src = erudite.parse(fs.readFileSync(filename, 'utf8'), opts);
 
 if (argv.stdout) {

--- a/bin/erudite
+++ b/bin/erudite
@@ -30,9 +30,13 @@ if (!fs.existsSync(filename)) {
   process.exit(1);
 }
 
-var src = erudite.parse(fs.readFileSync(filename, 'utf8'), {
-  stage: argv.e || argv.stage
-});
+var presets = []; // presets must be installed in the calling environment
+                  // (whether local or global), so do not enforce any
+var opts = { presets: presets };
+// note that -e or --stage may be specified as 0, hence need to test for undef
+var stage_preset = argv.e === undefined ? argv.stage : argv.e;
+if (stage_preset !== undefined) opts.presets.push('stage-' + argv.stage);
+var src = erudite.parse(fs.readFileSync(filename, 'utf8'), opts);
 
 if (argv.stdout) {
   return process.stdout.write(src);

--- a/index.js
+++ b/index.js
@@ -30,10 +30,14 @@ module.exports = erudite;
 
 // **parse** takes in Markdown `text`, extracts all indented and fenced code blocks,
 // returns the code blocks (concatenated; transpiled using [Babel](https://babeljs.io)).
-function parse (text, opts) {
-  opts = assign({ eol: os.EOL, stage: 2 }, opts);
+// Pass desired presets, plugins, and other [Babel options](https://babeljs.io/docs/core-packages/#options) in `opts`. No default presets etc are defined.
+ function parse (text, opts) {
+  opts = assign({ eol: os.EOL }, opts);
 
   var SEPARATOR = opts.eol + opts.eol;
+  // remove so that babel doesn't complain
+  delete opts.eol;
+
   var buf;
 
   // Break the Markdown `text` into tokens.
@@ -54,7 +58,7 @@ function parse (text, opts) {
   buf = Buffer.concat(codeBlocks);
 
   // Return the concatenated code blocks as a `Buffer`.
-  return new Buffer(babel.transform(buf.toString(), { stage: opts.stage }).code);
+  return new Buffer(babel.transform(buf.toString(), opts).code);
 }
 
 // **exec** takes a string of JavaScript as `src`, and runs it through a new
@@ -66,7 +70,7 @@ function exec (src, opts) {
   opts = assign({ filename: 'erudite' }, opts);
 
   // Load Babel polyfill
-  require('babel-core/polyfill');
+  require('babel-polyfill');
 
   // Create a new execution context, using `global` for seed values.
   var ctx = vm.createContext(global);

--- a/package.json
+++ b/package.json
@@ -22,12 +22,17 @@
   },
   "homepage": "https://github.com/artisonian/erudite",
   "dependencies": {
-    "babel-core": "^5.8.0",
+    "babel-core": "^6.21.0",
+    "babel-preset-env": "^1.1.6",
     "marked": "^0.3.6",
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0"
   },
   "devDependencies": {
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-polyfill": "^6.20.0",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
     "docco": "^0.7.0",
     "multiline": "^1.0.2",
     "tape": "^4.0.0"

--- a/test/erudite.test.js
+++ b/test/erudite.test.js
@@ -29,7 +29,7 @@ test('parses indented code blocks', function (t) {
     console.log(text);
   */});
 
-  t.equals(erudite.parse(src).toString(), expected);
+  t.equals(erudite.parse(src, { presets: ['es2015'] }).toString(), expected);
 });
 
 test('parses fenced code blocks', function (t) {
@@ -63,7 +63,7 @@ test('parses fenced code blocks', function (t) {
     console.log(add(2, 3));
   */});
 
-  t.equals(erudite.parse(src).toString(), expected);
+  t.equals(erudite.parse(src, { presets: ['es2015'] }).toString(), expected);
 });
 
 test('parses mixed code blocks', function (t) {
@@ -103,6 +103,7 @@ test('parses mixed code blocks', function (t) {
 
   var expected = m(function () {/*
     'use strict';
+
     var fs = require('fs');
     var stream = require('stream');
 
@@ -164,7 +165,6 @@ test('parses jsx code blocks', function (t) {
 
     var Panel = module.exports = React.createClass({
       displayName: "exports",
-
       render: function render() {
         return React.createElement(
           "div",
@@ -188,7 +188,7 @@ test('parses jsx code blocks', function (t) {
     });
   */});
 
-  t.equals(erudite.parse(src).toString(), expected);
+    t.equals(erudite.parse(src, { presets: ['es2015', 'react'] }).toString(), expected);
 });
 
 test('executes parsed code', function (t) {
@@ -238,7 +238,7 @@ test('parses ES6 syntax', function (t) {
         die.roll();
   */});
 
-  var ctx = erudite(src);
+  var ctx = erudite(src, { presets: ['es2015'] });
   t.ok(ctx.die instanceof ctx.Die);
   t.equals(ctx.description, '[Die sides:12]');
 });
@@ -255,7 +255,7 @@ test('includes Babel polyfill with executing', function (t) {
         Object.assign(car, { color: 'black' });
   */});
 
-  var ctx = erudite(src);
+  var ctx = erudite(src, { presets: ['es2015'] });
   t.equals(ctx.car.color, 'black');
 });
 
@@ -307,7 +307,9 @@ test('parses ES6+ syntax (using TC39 stages)', function (t) {
         let [first, second] = [die.roll(), die.roll()];
   */});
 
-  var ctx = erudite(src, { stage: 1 });
+  var ctx = erudite(src,
+                    { presets: ['es2015'],
+                      plugins: ['transform-decorators-legacy'] });
   t.ok(ctx.die instanceof ctx.Die);
   t.equals(typeof ctx.first, 'number');
   t.equals(typeof ctx.second, 'undefined');


### PR DESCRIPTION
Babel 6.x uses presets and plugins that need to be explicitly specified and installed.

To conserve behavior most closely to prior to this change, the `env` preset would be used as the default preset if none is specified by the user. However, that would in turn require the user to install this preset on their own; a dependency in this package does unfortunately not suffice.

Hence, there is no default preset, and if none are specified, the compiler simply reproduces the code it receives as input. This is, I think, in fact a valid use case, another reason not to set any default preset.

Also adds a repeatable `--preset` command line option to `bin/erudite`. This is so the Babel preset(s) can be chosen over the command line. More complex requirements (such as a mixture of presets and plugins) can be achieved by creating a [`.babelrc`](http://babeljs.io/docs/usage/babelrc/) file.

I've also added a `.travis.yml` file. This is so that you can see the result of the tests on various versions of NodeJS: <https://travis-ci.org/hlapp/erudite/builds/191838071>

I can remove the `.travis.yml` (or you can) if you want. However, you can also enable automatic testing through Travis yourself; it's free. The config file you need would be the one included here.