### PR TITLE
Removes unnecessary dependency on babel-preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/artisonian/erudite",
   "dependencies": {
     "babel-core": "^6.21.0",
-    "babel-preset-env": "^1.1.6",
     "marked": "^0.3.6",
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0"


### PR DESCRIPTION
In some ways this is minor (having the dependency when it's not strictly needed isn't going to render anything non-functional), but this particular dependency in npm <= 2.x results in a 380MB installed dep tree that doesn't serve a particular purpose.

This is a small fix to #9 that I just realized I forgot.